### PR TITLE
Install specific version of deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,25 @@ Downloads the latest Deno binary into `$HOME/.deno/bin`.
 **Install with Python:**
 
 ```
-curl -sSf https://raw.githubusercontent.com/denoland/deno_install/master/install.py | python
+curl -L https://deno.land/x/install/install.py | python
 ```
 
 **Install with PowerShell:**
 
 ```powershell
-iex (iwr https://raw.githubusercontent.com/denoland/deno_install/master/install.ps1)
+iex (iwr https://deno.land/x/install/install.ps1)
 ```
 
 _Note: Depending on your security settings, you may have to run `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` first to allow downloaded scripts to be executed._
+
+## Install other versions
+
+If you need to install specific version of deno, use the following commands:
+
+**Install with Python:**
+
+```
+curl -L https://deno.land/x/install/install.py | python - v0.2.0
+```
+
+(PowerShell version is not available yet)

--- a/install.py
+++ b/install.py
@@ -18,7 +18,9 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
-RELEASES_URL = "https://github.com/denoland/deno/releases/latest"
+DENO_REPO_URL = "https://github.com/denoland/deno"
+LATEST_RELEASE_URL = DENO_REPO_URL + "/releases/latest"
+TAG_URL = DENO_REPO_URL + "/releases/tag/"
 FILENAME_LOOKUP = {
     "darwin": "deno_osx_x64.gz",
     "linux": "deno_linux_x64.gz",  # python3
@@ -28,14 +30,21 @@ FILENAME_LOOKUP = {
 }
 
 
-def release_url(platform):
+def release_url(platform, tag):
     try:
         filename = FILENAME_LOOKUP[platform]
     except KeyError:
         print("Unable to locate appropriate filename for", platform)
         sys.exit(1)
 
-    html = urlopen(RELEASES_URL).read().decode('utf-8')
+    url = TAG_URL + tag if tag else LATEST_RELEASE_URL
+
+    try:
+        html = urlopen(url).read().decode('utf-8')
+    except:
+        print("Unable to find release page for", tag)
+        sys.exit(1)
+
     urls = re.findall(r'href=[\'"]?([^\'" >]+)', html)
     matching = [u for u in urls if filename in u]
 
@@ -50,7 +59,7 @@ def main():
     bin_dir = deno_bin_dir()
     exe_fn = os.path.join(bin_dir, "deno")
 
-    url = release_url(sys.platform)
+    url = release_url(sys.platform, sys.argv[1] if len(sys.argv) > 1 else None)
     print("Downloading", url)
     compressed = urlopen(url).read()
 

--- a/install_test.py
+++ b/install_test.py
@@ -10,11 +10,15 @@ import subprocess
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-def main():
+def bin_dir():
+    home = os.path.expanduser("~")
+    return os.path.join(home, ".deno", "bin")
+
+
+def test_install():
     os.chdir(this_dir)
     PATTERN = "DENO_EXE: "
-    home = os.path.expanduser("~")
-    expected_bin_dir = os.path.join(home, ".deno", "bin")
+    expected_bin_dir = bin_dir()
     print("Testing install.py ... Expect deno installed to ", expected_bin_dir)
     if os.path.exists(expected_bin_dir):
         shutil.rmtree(expected_bin_dir)
@@ -31,6 +35,27 @@ def main():
     assert actual_fn == expected_fn, "actual %s != expected %s" % (actual_fn,
                                                                    expected_fn)
     assert os.path.exists(actual_fn)
+
+
+def test_tag_install():
+    print(
+        "Testing install.py [tag_name] ... Expect specified version of deno installed"
+    )
+    cmd = [sys.executable, "install.py", "v0.1.11"]
+    out = subprocess.check_output(cmd, universal_newlines=True)
+
+    bin_path = os.path.join(bin_dir(), "deno")
+    cmd = [bin_path, "-v"]
+    out = subprocess.check_output(cmd, universal_newlines=True)
+
+    assert "deno: 0.1.11" in out, "installed deno version is not 0.1.11"
+    assert "v8: 7.1.302.4" in out, "v8 version is not 7.1.302.4"
+    assert "typescript: 3.1.3" in out, "typescript version is not 3.1.3"
+
+
+def main():
+    test_install()
+    test_tag_install()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With this change, we can install the specified version of deno with the following command:

```
curl -sSf https://raw.githubusercontent.com/denoland/deno_install/master/install.py | python - v0.1.12
```

refs: #10 