### PR TITLE
Update install.py to add .exe for windows

### DIFF
--- a/install.py
+++ b/install.py
@@ -81,7 +81,7 @@ def download_with_progress(url):
 
 def main():
     bin_dir = deno_bin_dir()
-    exe_fn = os.path.join(bin_dir, "deno")
+    exe_fn = os.path.join(bin_dir, "deno.exe" if sys.platform == "win32" else "deno")
 
     url = release_url(sys.platform, sys.argv[1] if len(sys.argv) > 1 else None)
     compressed = download_with_progress(url)


### PR DESCRIPTION
Update install.py to use '.exe' extension on windows so that `deno` can run successfully.  Addresses issue https://github.com/denoland/deno/issues/1429