### PR TITLE
Support installing a named version with powershell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,8 @@ If you need to install specific version of deno, use the following commands:
 curl -L https://deno.land/x/install/install.py | python - v0.2.0
 ```
 
-(PowerShell version is not available yet)
+**Install with PowerShell:**
+
+```powershell
+$install = iwr https://deno.land/x/install/install.ps1; iex "$install v0.2.0"
+```


### PR DESCRIPTION
Add support for specifying the version of deno when installing it with `install.ps1`.

```powershell
$install = iwr https://deno.land/x/install/install.ps1; iex "$install v0.2.0"
```

If no version is specified, the latest version is installed.

Closes: #10 