### PR TITLE
Improvements to PowerShell install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ curl -L https://deno.land/x/install/install.py | python - v0.2.0
 **Install with PowerShell:**
 
 ```powershell
-$install = iwr https://deno.land/x/install/install.ps1; iex "$install v0.2.0"
+iwr https://deno.land/x/install/install.ps1 -out install.ps1; .\install.ps1 v0.2.0
+```

--- a/README.md
+++ b/README.md
@@ -30,4 +30,8 @@ If you need to install specific version of deno, use the following commands:
 curl -L https://deno.land/x/install/install.py | python - v0.2.0
 ```
 
-(PowerShell version is not available yet)
+**Install with PowerShell:**
+
+```powershell
+$install = iwr https://deno.land/x/install/install.ps1; iex "$install v0.2.0"
+```

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,9 @@
 # Copyright 2018 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
-param 
+param (
+  [alias("v")]
+  [string] $version
+)
 ( 
     [alias("v")]
     [string]$version

--- a/install.ps1
+++ b/install.ps1
@@ -4,10 +4,6 @@ param (
   [alias("v")]
   [string] $version
 )
-( 
-    [alias("v")]
-    [string]$version
-)
 
 $ErrorActionPreference = "Stop"
 
@@ -39,14 +35,6 @@ if (-not $version) {
   Write-Done
 }
 
-# Download Deno release.
-$zip_file = "${deno_dir}\deno_win_x64.zip"
-$download_uri = "https://github.com/denoland/deno/releases/download/" +
-                "${version}/deno_win_x64.zip"
-Write-Part "Downloading "; Write-Emphasized $download_uri; Write-Part "..."
-Invoke-WebRequest -Uri $download_uri -OutFile $zip_file
-Write-Done
-
 # Create ~\.deno\bin directory if it doesn't already exist
 $deno_dir = "${Home}\.deno\bin"
 if (-not (Test-Path $deno_dir)) {
@@ -54,6 +42,14 @@ if (-not (Test-Path $deno_dir)) {
   New-Item -Path $deno_dir -ItemType Directory | Out-Null
   Write-Done
 }
+
+# Download Deno release.
+$zip_file = "${deno_dir}\deno_win_x64.zip"
+$download_uri = "https://github.com/denoland/deno/releases/download/" +
+                "${version}/deno_win_x64.zip"
+Write-Part "Downloading "; Write-Emphasized $download_uri; Write-Part "..."
+Invoke-WebRequest -Uri $download_uri -OutFile $zip_file
+Write-Done
 
 # Extract deno.exe from .zip file.
 Write-Part "Extracting "; Write-Emphasized $zip_file


### PR DESCRIPTION
Proposed changes to the install script:
- Make it more readable and easily maintainable thanks to named parameters;
Valid commands: `.\install.ps1 -v v0.2.0`, `.\install.ps1 -version v0.2.0`, `.\install.ps1 v0.2.0`
- Make possible the usage following command
`$install = iwr https://deno.land/x/install/install.ps1; iex "$install v0.2.0"`
This way the `install.ps1` file is not created needlessly after download.
This approach would not be possible with the previous implementation (correct me if I'm wrong).

No need to change code in CI. https://github.com/denoland/deno_std/pull/89