### PR TITLE
Re-add CI for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
       python:
         - "2.7"
         - "3.3"
-      # Test the install script.
       script:
         - ./install.py
         - ./install_test.py
@@ -17,21 +16,15 @@ matrix:
     - language: bash
       os:
         - linux
+        - osx
       addons:
         apt:
           packages:
             - ksh
             - zsh
-      env:
-        - PATH=$HOME/bin/:$PATH
-        - SHFMT_VERSION=v2.6.2
-        - SHFMT_DOWNLOAD_URL="https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
-      before_script:
-        - $SHELL --version 2>/dev/null || dpkg -s "$SHELL" 2>/dev/null || command -v "$SHELL"
-        - curl --version
-        - shellcheck --version
-        - curl -sSL "$SHFMT_DOWNLOAD_URL" -o $HOME/bin/shfmt;
-        - chmod +x $HOME/bin/shfmt;
-        - shfmt --version
+        homebrew:
+          packages:
+            - ksh
+            - zsh
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,18 @@ matrix:
     - language: bash
       os:
         - linux
-        - osx
       addons:
         apt:
           packages:
             - ksh
             - zsh
+      script:
+        - ./install_test.sh
+
+    - language: bash
+      os:
+        - osx
+      addons:
         homebrew:
           packages:
             - ksh

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,6 @@ matrix:
             - ksh
             - zsh
             - shellcheck
-      env:
-        - PATH=/usr/local/bin:$PATH
-        - SHFMT_OS=darwin
-        - SHFMT_VERSION=v2.6.2
-      before_script:
-        - curl -sSL -o "/usr/local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64"
-        - chmod +x "/usr/local/bin/shfmt"
+            - shfmt
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - SHFMT_OS=linux
         - SHFMT_VERSION=v2.6.2
       before_script:
-        - curl -sSL -o "$HOME/bin/shfmt" https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - curl -sSL -o "$HOME/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
         - chmod +x "$HOME/bin/shfmt"
       script:
         - ./install_test.sh
@@ -45,7 +45,7 @@ matrix:
         - SHFMT_OS=darwin
         - SHFMT_VERSION=v2.6.2
       before_script:
-        - curl -sSL -o "/usr/local/bin/shfmt" https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - curl -sSL -o "/usr/local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
         - chmod +x "/usr/local/bin/shfmt"
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ matrix:
           packages:
             - ksh
             - zsh
+      env:
+        - PATH=$HOME/bin/:$PATH
+        - SHFMT_OS=linux
+        - SHFMT_VERSION=v2.6.2
+      before_script:
+        - curl -sSL -o "$HOME/bin/shfmt" https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - chmod +x "$HOME/bin/shfmt"
       script:
         - ./install_test.sh
 
@@ -33,5 +40,12 @@ matrix:
             - ksh
             - zsh
             - shellcheck
+      env:
+        - PATH=/usr/local/bin:$PATH
+        - SHFMT_OS=darwin
+        - SHFMT_VERSION=v2.6.2
+      before_script:
+        - curl -sSL -o "/usr/local/bin/shfmt" https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - chmod +x "/usr/local/bin/shfmt"
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - SHFMT_OS=linux
         - SHFMT_VERSION=v2.6.2
       before_script:
-        - curl -sSL -o "$HOME/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - curl -sSL -o "$HOME/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64"
         - chmod +x "$HOME/bin/shfmt"
       script:
         - ./install_test.sh
@@ -45,7 +45,7 @@ matrix:
         - SHFMT_OS=darwin
         - SHFMT_VERSION=v2.6.2
       before_script:
-        - curl -sSL -o "/usr/local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64";
+        - curl -sSL -o "/usr/local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64"
         - chmod +x "/usr/local/bin/shfmt"
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
           packages:
             - ksh
             - zsh
+            - shellcheck
       env:
         - PATH=$HOME/bin/:$PATH
         - SHFMT_VERSION=v2.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,6 @@ matrix:
           packages:
             - ksh
             - zsh
+            - shellcheck
       script:
         - ./install_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
       addons:
         apt:
           packages:
-            - ksh
-            - zsh
             - shellcheck
       env:
         - PATH=$HOME/bin/:$PATH
@@ -37,8 +35,6 @@ matrix:
       addons:
         homebrew:
           packages:
-            - ksh
-            - zsh
             - shellcheck
             - shfmt
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ matrix:
             - zsh
       env:
         - PATH=$HOME/bin/:$PATH
-        - SHFMT_OS=linux
         - SHFMT_VERSION=v2.6.2
       before_script:
-        - curl -sSL -o "$HOME/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${SHFMT_OS}_amd64"
+        - curl -sSL -o "$HOME/bin/shfmt" "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
         - chmod +x "$HOME/bin/shfmt"
       script:
         - ./install_test.sh

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ esac
 
 if [ $# -eq 0 ]; then
 	deno_asset_path=$(curl -sSf https://github.com/denoland/deno/releases |
-		grep -o "/denoland/deno/releases/download/.*/deno_${os}_x64\.gz" |
+		grep -o "/denoland/deno/releases/download/.*/deno_${os}_x64\\.gz" |
 		head -n 1)
 	if [ ! "$deno_asset_path" ]; then exit 1; fi
 	deno_uri="https://github.com${deno_asset_path}"

--- a/install_test.sh
+++ b/install_test.sh
@@ -2,18 +2,8 @@
 
 set -ev
 
-# Install shfmt.
-shfmt_version=v2.6.2
-case $(uname -s) in
-Darwin) shfmt_os="darwin" ;;
-*) shfmt_os="linux" ;;
-esac
-shfmt_url="https://github.com/mvdan/sh/releases/download/${shfmt_version}/shfmt_${shfmt_version}_${shfmt_os}_amd64"
-curl -sSL -o ./shfmt "$shfmt_url"
-chmod +x ./shfmt
-
 # Check formatting.
-./shfmt -d .
+shfmt -d .
 
 # Lint code.
 shellcheck -s sh ./install.sh
@@ -32,8 +22,8 @@ test_latest_version() {
 }
 
 case $(uname -s) in
-Darwin) shells=(sh bash ksh zsh) ;;
-*) shells=(sh bash dash ksh zsh) ;;
+Darwin) shells=(bash ksh zsh) ;;
+*) shells=(dash ksh zsh) ;;
 esac
 
 for shell in $"${shells[@]}"; do

--- a/install_test.sh
+++ b/install_test.sh
@@ -2,18 +2,16 @@
 
 set -ev
 
-# Check formatting.
+# Lint.
+shellcheck -s sh ./*.sh
 shfmt -d .
 
-# Lint code.
-shellcheck -s sh ./*.sh
-
-# Test installing a specific version.
+# Test we can install a specific version.
 rm -rf ~/.deno
-sh install.sh v0.2.0
+./install.sh v0.2.0
 ~/.deno/bin/deno -v | grep -e 0.2.0
 
-# Test installing the latest version.
+# Test we can get the latest version.
 rm -rf ~/.deno
-sh install.sh
+sh ./install.sh
 ~/.deno/bin/deno -v

--- a/install_test.sh
+++ b/install_test.sh
@@ -21,12 +21,16 @@ test_latest_version() {
 	~/.deno/bin/deno -v
 }
 
-case $(uname -s) in
-Darwin) shells=(bash ksh zsh) ;;
-*) shells=(dash ksh zsh) ;;
-esac
-
-for shell in $"${shells[@]}"; do
-	test_specific_version $shell
-	test_latest_version $shell
-done
+if [ ! "$CI" ]; then
+	test_specific_version sh
+	test_latest_version sh
+else
+	case $(uname -s) in
+	Darwin) shells=(bash ksh zsh) ;;
+	*) shells=(dash ksh zsh) ;;
+	esac
+	for shell in $"${shells[@]}"; do
+		test_specific_version $shell
+		test_latest_version $shell
+	done
+fi

--- a/install_test.sh
+++ b/install_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ev
 
 PATH=$HOME/bin/:$PATH
 

--- a/install_test.sh
+++ b/install_test.sh
@@ -18,8 +18,6 @@ chmod +x ./shfmt
 # Lint code.
 shellcheck -s bash ./*.sh
 shellcheck -s sh ./install.sh
-shellcheck -s dash ./install.sh
-shellcheck -s ksh ./install.sh
 
 test_specific_version() {
 	rm -rf ~/.deno

--- a/install_test.sh
+++ b/install_test.sh
@@ -16,8 +16,8 @@ chmod +x ./shfmt
 ./shfmt -d .
 
 # Lint code.
-shellcheck -s bash ./*.sh
 shellcheck -s sh ./install.sh
+shellcheck -s bash ./install_test.sh
 
 test_specific_version() {
 	rm -rf ~/.deno

--- a/install_test.sh
+++ b/install_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ev
 
@@ -6,31 +6,14 @@ set -ev
 shfmt -d .
 
 # Lint code.
-shellcheck -s sh ./install.sh
-shellcheck -s bash ./install_test.sh
+shellcheck -s sh ./*.sh
 
-test_specific_version() {
-	rm -rf ~/.deno
-	$1 install.sh v0.2.0
-	~/.deno/bin/deno -v | grep -e 0.2.0
-}
+# Test installing a specific version.
+rm -rf ~/.deno
+sh install.sh v0.2.0
+~/.deno/bin/deno -v | grep -e 0.2.0
 
-test_latest_version() {
-	rm -rf ~/.deno
-	$1 install.sh
-	~/.deno/bin/deno -v
-}
-
-if [ ! "$CI" ]; then
-	test_specific_version sh
-	test_latest_version sh
-else
-	case $(uname -s) in
-	Darwin) shells=(bash ksh zsh) ;;
-	*) shells=(dash ksh zsh) ;;
-	esac
-	for shell in $"${shells[@]}"; do
-		test_specific_version $shell
-		test_latest_version $shell
-	done
-fi
+# Test installing the latest version.
+rm -rf ~/.deno
+sh install.sh
+~/.deno/bin/deno -v

--- a/install_test.sh
+++ b/install_test.sh
@@ -24,10 +24,10 @@ shfmt --version
 shfmt -d .
 
 # Lint code.
-shellcheck -s sh ./*.sh
 shellcheck -s bash ./*.sh
-shellcheck -s dash ./*.sh
-shellcheck -s ksh ./*.sh
+shellcheck -s sh ./install.sh
+shellcheck -s dash ./install.sh
+shellcheck -s ksh ./install.sh
 
 test_specific_version() {
 	rm -rf ~/.deno

--- a/install_test.sh
+++ b/install_test.sh
@@ -1,17 +1,52 @@
-#!/bin/sh
+#!/bin/bash
 
-set -ev
+set -e
 
-# Lint.
-shellcheck -s sh ./*.sh
+PATH=$HOME/bin/:$PATH
+
+# Install shfmt.
+shfmt_version=v2.6.2
+case $(uname -s) in
+Darwin) shfmt_os="darwin" ;;
+*) shfmt_os="linux" ;;
+esac
+shfmt_url="https://github.com/mvdan/sh/releases/download/${shfmt_version}/shfmt_${shfmt_version}_${shfmt_os}_amd64"
+curl -sSL -o "$HOME/bin/shfmt" "$shfmt_url"
+chmod +x "$HOME/bin/shfmt"
+
+# Print versions.
+$SHELL --version
+curl --version
+shellcheck --version
+shfmt --version
+
+# Check formatting.
 shfmt -d .
 
-# Test we can install a specific version
-rm -rf ~/.deno
-./install.sh v0.2.0
-~/.deno/bin/deno -v | grep -e 0.2.0
+# Lint code.
+shellcheck -s sh ./*.sh
+shellcheck -s bash ./*.sh
+shellcheck -s dash ./*.sh
+shellcheck -s ksh ./*.sh
 
-# Test we can get the latest version.
-rm -rf ~/.deno
-sh ./install.sh
-~/.deno/bin/deno -v
+test_specific_version() {
+	rm -rf ~/.deno
+	$1 install.sh v0.2.0
+	~/.deno/bin/deno -v | grep -e 0.2.0
+}
+
+test_latest_version() {
+	rm -rf ~/.deno
+	$1 install.sh
+	~/.deno/bin/deno -v
+}
+
+case $(uname -s) in
+Darwin) shells=(sh bash ksh zsh) ;;
+*) shells=(sh bash dash ksh zsh) ;;
+esac
+
+for shell in $"${shells[@]}"; do
+	test_specific_version $shell
+	test_latest_version $shell
+done

--- a/install_test.sh
+++ b/install_test.sh
@@ -2,8 +2,6 @@
 
 set -ev
 
-PATH=$HOME/bin/:$PATH
-
 # Install shfmt.
 shfmt_version=v2.6.2
 case $(uname -s) in
@@ -11,8 +9,8 @@ Darwin) shfmt_os="darwin" ;;
 *) shfmt_os="linux" ;;
 esac
 shfmt_url="https://github.com/mvdan/sh/releases/download/${shfmt_version}/shfmt_${shfmt_version}_${shfmt_os}_amd64"
-curl -sSL -o "$HOME/bin/shfmt" "$shfmt_url"
-chmod +x "$HOME/bin/shfmt"
+curl -sSL -o ./shfmt "$shfmt_url"
+chmod +x ./shfmt
 
 # Print versions.
 $SHELL --version
@@ -21,7 +19,7 @@ shellcheck --version
 shfmt --version
 
 # Check formatting.
-shfmt -d .
+./shfmt -d .
 
 # Lint code.
 shellcheck -s bash ./*.sh

--- a/install_test.sh
+++ b/install_test.sh
@@ -12,12 +12,6 @@ shfmt_url="https://github.com/mvdan/sh/releases/download/${shfmt_version}/shfmt_
 curl -sSL -o ./shfmt "$shfmt_url"
 chmod +x ./shfmt
 
-# Print versions.
-$SHELL --version
-curl --version
-shellcheck --version
-shfmt --version
-
 # Check formatting.
 ./shfmt -d .
 


### PR DESCRIPTION
- Re-add testing the `sh` installer on `osx`
- ~~Re-add testing the `sh` installer with different shells (`ksh`, `zsh`, `dash`, `bash`, and `sh`)~~

See: [#30](https://github.com/denoland/deno_install/issues/30).