### PR TITLE
Fix PowerShell IsWindows usage

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,41 +10,38 @@ param (
 $ErrorActionPreference = 'Stop'
 
 if ($PSVersionTable.PSVersion.Major -lt 6) {
-  $IsWin = $true
-  $IsOsx = $false
-} else {
-  $IsWin = $IsWindows
-  $IsOsx = $IsMacOS
+  $IsWindows = $true
+  $IsMacOS = $false
 }
 
-$BinDir = if ($IsWin) {
+$BinDir = if ($IsWindows) {
   "$Home\.deno\bin"
 } else {
   "$Home/.deno/bin"
 }
 
-$Zip = if ($IsWin) {
+$Zip = if ($IsWindows) {
   'zip'
 } else {
   'gz'
 }
 
-$DenoZip = if ($IsWin) {
+$DenoZip = if ($IsWindows) {
   "$BinDir\deno.$Zip"
 } else {
   "$BinDir/deno.$Zip"
 }
 
-$DenoExe = if ($IsWin) {
+$DenoExe = if ($IsWindows) {
   "$BinDir\deno.exe"
 } else {
   "$BinDir/deno"
 }
 
-$OS = if ($IsWin) {
+$OS = if ($IsWindows) {
   'win'
 } else {
-  if ($IsOsx) {
+  if ($IsMacOS) {
     'osx'
   } else {
     'linux'

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -10,16 +10,14 @@ if (!(Get-Module PSScriptAnalyzer -ListAvailable)) {
   Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
 }
 
-Invoke-ScriptAnalyzer *.ps1 -EnableExit
+Invoke-ScriptAnalyzer *.ps1 -Exclude PSAvoidAssignmentToAutomaticVariable
 
-$IsWin = if ($PSVersionTable.PSVersion.Major -lt 6) {
-  $true
-} else {
-  $IsWindows
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+  $IsWindows = $true
 }
 
 .\install.ps1 v0.2.0
-$DenoVersion = if ($IsWin) {
+$DenoVersion = if ($IsWindows) {
   deno --version
 } else {
   ~/.deno/bin/deno --version
@@ -31,7 +29,7 @@ if (!($DenoVersion[0] -eq 'deno: 0.2.0')) {
 }
 
 .\install.ps1
-$DenoVersion = if ($IsWin) {
+$DenoVersion = if ($IsWindows) {
   deno --version
 } else {
   ~/.deno/bin/deno --version


### PR DESCRIPTION
Just noticed a broken refactoring when it crashed the deno_std CI: https://dev.azure.com/denoland/deno_std/_build/results?buildId=415

`$IsWindows` is built-in in PowerShell >v6. So I added `if ($PSVersionTable.PSVersion.Major -lt 6) { $IsWindows = $true }` to basically polyfill the variable for older versions. The linter complained about it. So instead I assigned `$IsWindows` to `$IsWin` on PowerShell >v6 and assigned `$true` to `$IsWin` on older PowerShell versions. Unfortunately, I missed two places where it was not renamed.

This PR fixes that. However, instead of renaming the two missing places, I'm excluding the `PSAvoidAssignmentToAutomaticVariable` linting rule, and use the original polyfill approach instead. I think that makes the code a bit simpler to reason about, and it's easier to understand that these are built-in variables. (The `$IsMacOS` variable is also used.)

@ry Can you review?