### PR TITLE
Use version subcommand

### DIFF
--- a/install_test.ps1
+++ b/install_test.ps1
@@ -25,13 +25,13 @@ $BinDir = if ($IsWindows) {
 
 # Test we can install a specific version.
 Remove-Item $BinDir -Recurse -Force -ErrorAction SilentlyContinue
-.\install.ps1 v0.2.10
+.\install.ps1 v0.3.10
 $DenoVersion = if ($IsWindows) {
-  deno --version
+  deno version
 } else {
-  ~/.deno/bin/deno --version
+  ~/.deno/bin/deno version
 }
-if (!($DenoVersion -like '*0.2.10*')) {
+if (!($DenoVersion -like '*0.3.10*')) {
   throw $DenoVersion
 }
 
@@ -39,7 +39,7 @@ if (!($DenoVersion -like '*0.2.10*')) {
 Remove-Item $BinDir -Recurse -Force -ErrorAction SilentlyContinue
 .\install.ps1
 if ($IsWindows) {
-  deno --version
+  deno version
 } else {
-  ~/.deno/bin/deno --version
+  ~/.deno/bin/deno version
 }

--- a/install_test.sh
+++ b/install_test.sh
@@ -8,10 +8,10 @@ shfmt -d .
 
 # Test we can install a specific version.
 rm -rf ~/.deno
-./install.sh v0.2.10
-~/.deno/bin/deno -v | grep 0.2.10
+./install.sh v0.3.10
+~/.deno/bin/deno version | grep 0.3.10
 
 # Test we can install the latest version.
 rm -rf ~/.deno
 sh ./install.sh
-~/.deno/bin/deno -v
+~/.deno/bin/deno version


### PR DESCRIPTION
`deno --version` has become to `deno version` since v0.3.10 (PR: https://github.com/denoland/deno/pull/2212). This PR updates the command according to that change.


---
fixes #59 