### PR TITLE
Add support for DENO_DIR in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+# Copyright 2019 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
 set -e

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,11 @@ if [ "$arch" = "other" ]; then
 fi
 
 if [ $# -eq 0 ]; then
-	deno_asset_path=$(curl -sSf https://github.com/denoland/deno/releases |
-		grep -o "/denoland/deno/releases/download/.*/deno_${os}_x64\\.gz" |
-		head -n 1)
+	deno_asset_path=$(
+		command curl -sSf https://github.com/denoland/deno/releases |
+			command grep -o "/denoland/deno/releases/download/.*/deno_${os}_x64\\.gz" |
+			command head -n 1
+	)
 	if [ ! "$deno_asset_path" ]; then exit 1; fi
 	deno_uri="https://github.com${deno_asset_path}"
 else

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,8 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno_${os}_x64.gz"
 fi
 
-bin_dir="$HOME/.deno/bin"
+deno_dir=${DENO_DIR:-$HOME/.deno}
+bin_dir="${deno_dir}/bin"
 exe="$bin_dir/deno"
 
 if [ ! -d "$bin_dir" ]; then

--- a/install_test.sh
+++ b/install_test.sh
@@ -8,10 +8,10 @@ shfmt -d .
 
 # Test we can install a specific version.
 rm -rf ~/.deno
-./install.sh v0.3.10
+DENO_DIR='' ./install.sh v0.3.10
 ~/.deno/bin/deno version | grep 0.3.10
 
 # Test we can install the latest version.
 rm -rf ~/.deno
-sh ./install.sh
-~/.deno/bin/deno version
+DENO_DIR="$HOME/.deno-test" sh ./install.sh
+~/.deno-test/bin/deno version


### PR DESCRIPTION
Also prefixed commands with `command` just in case someone has aliased `grep` to something, say, like `rg` :)

I have only tested on ubuntu 18.04, and ran the test script of course.