### PR TITLE
Use DENO_INSTALL instead of DENO_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ scoop install deno
 brew install deno
 ```
 
+## Environment Variables
+
+- `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`. Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).
+
 ## Compatibility
 
 - The Shell installer can be used on Windows via the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ brew install deno
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`. Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).
+- `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
+Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).
+
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ brew install deno
 ## Environment Variables
 
 - `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
+  One application of this is a system-wide Shell installation to [`/opt/deno`](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s13.html):
+
+  ```sh
+  curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/opt/deno sh -s v0.2.10
+  ```
+
   Not yet supported in the PowerShell installer (#76).
 
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ brew install deno
 ## Environment Variables
 
 - `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
-Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).
+  Not yet supported in the PowerShell installer (#76).
 
 
 ## Compatibility

--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,8 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno_${os}_x64.gz"
 fi
 
-deno_dir=${DENO_DIR:-$HOME/.deno}
-bin_dir="${deno_dir}/bin"
+deno_install=${DENO_INSTALL:-$HOME/.deno}
+bin_dir="${deno_install}/bin"
 exe="$bin_dir/deno"
 
 if [ ! -d "$bin_dir" ]; then
@@ -48,6 +48,7 @@ if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"
 else
 	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
-	echo "  export PATH=\"$bin_dir:\$PATH\""
+	echo "  export DENO_INSTALL=\"$deno_install\""
+	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install_test.sh
+++ b/install_test.sh
@@ -8,10 +8,10 @@ shfmt -d .
 
 # Test we can install a specific version.
 rm -rf ~/.deno
-DENO_DIR='' ./install.sh v0.3.10
+DENO_INSTALL='' ./install.sh v0.3.10
 ~/.deno/bin/deno version | grep 0.3.10
 
 # Test we can install the latest version.
 rm -rf ~/.deno
-DENO_DIR="$HOME/.deno-test" sh ./install.sh
+DENO_INSTALL="$HOME/.deno-test" sh ./install.sh
 ~/.deno-test/bin/deno version


### PR DESCRIPTION
The install script is the only place in denoland where the cache directory variable `$DENO_DIR` is also used to determine Deno's installation directory. This separates the two into `$DENO_DIR` and `$DENO_HOME`.

Now `$DENO_HOME` can be set to a custom location in your profile (for updates or third party tools) without the cache defaulting to the same, potentially root-owned, location.

cc @ry