### PR TITLE
Update powershell version in mac and linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,3 @@
 build: off
 test_script:
   - ps: .\install_test.ps1
-  - pwsh install_test.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
             - shellcheck
       env:
         - SHFMT_VERSION=2.6.2
-        - PWSH_VERSION=6.1.2
+        - PWSH_VERSION=6.2.3
         - PATH=$HOME/bin/pwsh:$HOME/bin:$PATH
       before_script:
         - curl -sSL -o $HOME/bin/shfmt https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64
@@ -31,7 +31,7 @@ matrix:
             - shellcheck
             - shfmt
       env:
-        - PWSH_VERSION=6.1.2
+        - PWSH_VERSION=6.2.3
         - PATH=$HOME/bin/pwsh:$PATH
       before_script:
         - mkdir -p $HOME/bin/pwsh


### PR DESCRIPTION
It seems that minimum supported version of PSScriptAnalyzer for PowerShell Core is now 6.2.0 according to the error message when calling `Import-Module PSScriptAnalyzer`. This PR updates the powershell version to v6.2.3.

```
PS /Users/kt3k/s/deno_std> Import-Module PSScriptAnalyzer
Import-Module : Minimum supported version of PSScriptAnalyzer for PowerShell Core is 6.2.0 but current version is '6.1.2'. Please update PowerShell Core.
At line:1 char:1
+ Import-Module PSScriptAnalyzer
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (Minimum support...owerShell Core.:String) [Import-Module], RuntimeException
+ FullyQualifiedErrorId : Minimum supported version of PSScriptAnalyzer for PowerShell Core is 6.2.0 but current version is '6.1.2'. Please update PowerShell Core.,Microsoft.PowerShell.Commands.ImportModuleCommand
```

closes #77 