### PR TITLE
fix: Don't use version as a subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ asdf local deno 0.2.10
   curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/opt/deno sh
   ```
 
-  Not yet supported in the PowerShell installer (#76).
+  Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).
 
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ asdf local deno 0.2.10
 ## Environment Variables
 
 - `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
-  One application of this is a system-wide Shell installation to [`/opt/deno`](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s13.html):
+  One application of this is a system-wide Shell installation to `/usr/local/bin`:
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/opt/deno sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local/bin sh
   ```
 
   Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ asdf local deno 0.2.10
 ## Environment Variables
 
 - `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
-  One application of this is a system-wide Shell installation to `/usr/local/bin`:
+  One application of this is a system-wide Shell installation to `/usr/local`:
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local/bin sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh
   ```
 
   Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ asdf local deno 0.2.10
   One application of this is a system-wide Shell installation to [`/opt/deno`](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s13.html):
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/opt/deno sh -s v0.2.10
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/opt/deno sh
   ```
 
   Not yet supported in the PowerShell installer (#76).

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -25,13 +25,13 @@ $BinDir = if ($IsWindows) {
 
 # Test we can install a specific version.
 Remove-Item $BinDir -Recurse -Force -ErrorAction SilentlyContinue
-.\install.ps1 v0.3.10
+.\install.ps1 v0.13.0
 $DenoVersion = if ($IsWindows) {
-  deno version
+  deno --version
 } else {
-  ~/.deno/bin/deno version
+  ~/.deno/bin/deno --version
 }
-if (!($DenoVersion -like '*0.3.10*')) {
+if (!($DenoVersion -like '*0.13.0*')) {
   throw $DenoVersion
 }
 
@@ -39,7 +39,7 @@ if (!($DenoVersion -like '*0.3.10*')) {
 Remove-Item $BinDir -Recurse -Force -ErrorAction SilentlyContinue
 .\install.ps1
 if ($IsWindows) {
-  deno version
+  deno --version
 } else {
-  ~/.deno/bin/deno version
+  ~/.deno/bin/deno --version
 }

--- a/install_test.sh
+++ b/install_test.sh
@@ -7,10 +7,10 @@ set -e
 
 # Test we can install a specific version.
 rm -rf ~/.deno
-DENO_INSTALL='' ./install.sh v0.3.10
-~/.deno/bin/deno version | grep 0.3.10
+DENO_INSTALL='' ./install.sh v0.13.0
+~/.deno/bin/deno --version | grep 0.13.0
 
 # Test we can install the latest version.
 rm -rf ~/.deno
 DENO_INSTALL="$HOME/.deno-test" sh ./install.sh
-~/.deno-test/bin/deno version
+~/.deno-test/bin/deno --version


### PR DESCRIPTION
DENO_INSTALL example: Adds `sudo`, removes unnecessary version specification.

Edit: Whatever, I'll just make this about the version subcommand thing.