### PR TITLE
Default DENO_INSTALL to $HOME/.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ asdf local deno 0.2.10
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. This defaults to `$HOME/.deno`.
-  One application of this is a system-wide Shell installation to `/usr/local`:
+- `DENO_INSTALL` - The directory in which to install Deno. On Linux, this defaults to `$XDG_BIN_HOME` or `$HOME/.local/bin`.
+  One application of this is a system-wide Shell installation to `/usr/local/bin`:
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local/bin sh
   ```
 
   Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ asdf local deno 0.2.10
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. On Linux, this defaults to `$XDG_BIN_HOME` or `$HOME/.local/bin`.
-  One application of this is a system-wide Shell installation to `/usr/local/bin`:
+- `DENO_INSTALL` - The directory in which to install Deno. On Linux, this defaults to `$HOME/.local/bin`.
+  One application of this is a system-wide Shell installation to `/usr/local`:
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local/bin sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh
   ```
 
   Not yet supported in the PowerShell installer ([#76](https://github.com/denoland/deno_install/issues/76)).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ asdf local deno 0.2.10
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. On Linux, this defaults to `$HOME/.local/bin`.
+- `DENO_INSTALL` - The directory in which to install Deno. On Linux, this defaults to `$HOME/.local`.
   One application of this is a system-wide Shell installation to `/usr/local`:
 
   ```sh

--- a/install.sh
+++ b/install.sh
@@ -31,12 +31,12 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno_${os}_x64.gz"
 fi
 
-deno_install=${DENO_INSTALL:-$HOME/.deno}
-bin_dir="${deno_install}/bin"
-exe="$bin_dir/deno"
+xdg_bin_home=${XDG_BIN_HOME:-$HOME/.local/bin}
+deno_install=${DENO_INSTALL:-$xdg_bin_home}
+exe="$deno_install/deno"
 
-if [ ! -d "$bin_dir" ]; then
-	mkdir -p "$bin_dir"
+if [ ! -d "$deno_install" ]; then
+	mkdir -p "$deno_install"
 fi
 
 curl -fL# -o "$exe.gz" "$deno_uri"
@@ -49,6 +49,6 @@ if command -v deno >/dev/null; then
 else
 	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
+	echo "  export PATH=\"\$DENO_INSTALL:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install.sh
+++ b/install.sh
@@ -31,12 +31,12 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno_${os}_x64.gz"
 fi
 
-xdg_bin_home=${XDG_BIN_HOME:-$HOME/.local/bin}
-deno_install=${DENO_INSTALL:-$xdg_bin_home}
-exe="$deno_install/deno"
+deno_install=${DENO_INSTALL:-$HOME/.local}
+bin_dir=$deno_install/bin
+exe="$bin_dir/deno"
 
-if [ ! -d "$deno_install" ]; then
-	mkdir -p "$deno_install"
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
 fi
 
 curl -fL# -o "$exe.gz" "$deno_uri"
@@ -49,6 +49,6 @@ if command -v deno >/dev/null; then
 else
 	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"\$DENO_INSTALL:\$PATH\""
+	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,8 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno_${os}_x64.gz"
 fi
 
-deno_install=${DENO_INSTALL:-$HOME/.local}
-bin_dir=$deno_install/bin
+deno_install="${DENO_INSTALL:-$HOME/.local}"
+bin_dir="$deno_install/bin"
 exe="$bin_dir/deno"
 
 if [ ! -d "$bin_dir" ]; then

--- a/install_test.sh
+++ b/install_test.sh
@@ -6,12 +6,11 @@ set -e
 # TODO(ry) shellcheck -s sh ./*.sh
 
 # Test that we can install the latest version at the default location.
-unset XDG_BIN_HOME
 unset DENO_INSTALL
 sh ./install.sh
 ~/.local/bin/deno --version
 
 # Test that we can install a specific version at a custom location.
-export DENO_INSTALL="$HOME/deno-0.13.0/bin"
+export DENO_INSTALL="$HOME/deno-0.13.0"
 ./install.sh v0.13.0
 ~/deno-0.13.0/bin/deno --version | grep 0.13.0

--- a/install_test.sh
+++ b/install_test.sh
@@ -5,12 +5,13 @@ set -e
 # Lint.
 # TODO(ry) shellcheck -s sh ./*.sh
 
-# Test we can install a specific version.
-rm -rf ~/.deno
-DENO_INSTALL='' ./install.sh v0.13.0
-~/.deno/bin/deno --version | grep 0.13.0
+# Test that we can install the latest version at the default location.
+unset XDG_BIN_HOME
+unset DENO_INSTALL
+sh ./install.sh
+~/.local/bin/deno --version
 
-# Test we can install the latest version.
-rm -rf ~/.deno
-DENO_INSTALL="$HOME/.deno-test" sh ./install.sh
-~/.deno-test/bin/deno --version
+# Test that we can install a specific version at a custom location.
+export DENO_INSTALL="$HOME/deno-0.13.0/bin"
+./install.sh v0.13.0
+~/deno-0.13.0/bin/deno --version | grep 0.13.0


### PR DESCRIPTION
Closes #40.

~To make `DENO_INSTALL` compatible with `XDG_BIN_HOME`, it now points to the binary directory directly rather than having `bin` appended to it. i.e. Installing to `/usr/local/bin` required `DENO_INSTALL=/usr/local`, now it would be `DENO_INSTALL=/usr/local/bin`.~

cc @ry