### PR TITLE
Trivial installer messaging update on the post install.sh default shell profile filename path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,13 +48,8 @@ if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"
 else
 	case $SHELL in
-	/bin/zsh)
-		shell_profile=".zshrc"
-		break
-		;;
-	*)
-		shell_profile=".bash_profile"
-		;;
+	/bin/zsh) shell_profile=".zshrc" ;;
+	*) shell_profile=".bash_profile" ;;
 	esac
 	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""

--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,17 @@ echo "Deno was installed successfully to $exe"
 if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"
 else
-	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
+	case $SHELL in
+	/bin/zsh)
+		shell_profile_filename=".zshrc"
+		break
+		;;
+	*)
+		shell_profile_filename=".bash_profile"
+		;;
+	esac
+	echo "Manually add the directory to your \$HOME/$shell_profile_filename (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
+	echo '  export PATH="$DENO_INSTALL/bin:$PATH"'
 	echo "Run '$exe --help' to get started"
 fi

--- a/install.sh
+++ b/install.sh
@@ -49,14 +49,14 @@ if command -v deno >/dev/null; then
 else
 	case $SHELL in
 	/bin/zsh)
-		shell_profile_filename=".zshrc"
+		shell_profile=".zshrc"
 		break
 		;;
 	*)
-		shell_profile_filename=".bash_profile"
+		shell_profile=".bash_profile"
 		;;
 	esac
-	echo "Manually add the directory to your \$HOME/$shell_profile_filename (or similar)"
+	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""
 	echo '  export PATH="$DENO_INSTALL/bin:$PATH"'
 	echo "Run '$exe --help' to get started"


### PR DESCRIPTION
Added a minor/trivial case statement to check `$SHELL` environment variable and suggest the correct path based on the users actual running shell.

Reasoning is that many (specifically: macOS) users are running newer versions of macOS Catalina or higher which come shipped with `zsh` by default. 

(Ref: https://support.apple.com/en-us/HT208050)

