### PR TITLE
Restrict Set-ExecutionPolicy scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ If your systems' [ExecutionPolicy](https://docs.microsoft.com/en-us/powershell/m
 
 **How can this issue be fixed?**
 
-Allow scripts that are downloaded from the internet to be executed by setting the execution policy to `RemoteSigned`:
+Allow scripts that are downloaded from the internet to be executed by setting the execution policy to `RemoteSigned` for your terminal session:
 
 ```powershell
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+Set-ExecutionPolicy RemoteSigned -Scope Process -Force
 ```


### PR DESCRIPTION
Restrict the scope on the recommended fix for the Powershell execution error. The options for the -Scope flag are "LocalMachine" (default), "CurrentUser", "Process", "UserPolicy" or "MachinePolicy". "Process" is the only option that doesn't make a permanent change -- it **only** allows the install script to run in the current Powershell session.

More info on -Scope here https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7