### PR TITLE
Revert "Default DENO_INSTALL to $HOME/.local (#89)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,8 @@ scoop reset deno
 ## Environment Variables
 
 - `DENO_INSTALL` - The directory in which to install Deno. This defaults to
-  `$HOME/.local` on Linux/macOS and `$HOME/.deno` on Windows. The executable
-  is placed in `$DENO_INSTALL/bin`. One application of this is a system-wide
-  installation:
+  `$HOME/.deno`. The executable is placed in `$DENO_INSTALL/bin`. One
+  application of this is a system-wide installation:
 
   **With Shell (`/usr/local`):**
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno-${target}.zip"
 fi
 
-deno_install="${DENO_INSTALL:-$HOME/.local}"
+deno_install="${DENO_INSTALL:-$HOME/.deno}"
 bin_dir="$deno_install/bin"
 exe="$bin_dir/deno"
 

--- a/install_test.sh
+++ b/install_test.sh
@@ -6,10 +6,10 @@ set -e
 # TODO(ry) shellcheck -s sh ./*.sh
 
 # Test that we can install the latest version at the default location.
-rm -f ~/.local/bin/deno
+rm -f ~/.deno/bin/deno
 unset DENO_INSTALL
 sh ./install.sh
-~/.local/bin/deno --version
+~/.deno/bin/deno --version
 
 # Test that we can install a specific version at a custom location.
 rm -rf ~/deno-0.38.0


### PR DESCRIPTION
Ref https://github.com/denoland/deno/pull/4582#issuecomment-607937323, #89, #40

Problems with `~/.local/bin`:
- Hard to uninstall Deno along with `deno install`ed addons.
- Not as conventional.