### PR TITLE
Change DENO_INSTALL to DENO_INSTALL_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,21 @@ scoop reset deno
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. This defaults to
-  `$HOME/.deno`. The executable is placed in `$DENO_INSTALL/bin`. One
+- `DENO_INSTALL_ROOT` - The directory in which to install Deno. This defaults to
+  `$HOME/.deno`. The executable is placed in `$DENO_INSTALL_ROOT/bin`. One
   application of this is a system-wide installation:
 
   **With Shell (`/usr/local`):**
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL_ROOT=/usr/local sh
   ```
 
   **With PowerShell (`C:\Program Files\deno`):**
 
   ```powershell
   # Run as administrator:
-  $env:DENO_INSTALL = "C:\Program Files\deno"
+  $env:DENO_INSTALL_ROOT = "C:\Program Files\deno"
   iwr https://deno.land/x/install/install.ps1 -useb | iex
   ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,7 +13,7 @@ if ($PSVersionTable.PSEdition -ne 'Core') {
   $IsMacOS = $false
 }
 
-$DenoInstall = $env:DENO_INSTALL
+$DenoInstall = $env:DENO_INSTALL_ROOT
 $BinDir = if ($DenoInstall) {
     "$DenoInstall\bin"
 } elseif ($IsWindows) {

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno-${target}.zip"
 fi
 
-deno_install="${DENO_INSTALL:-$HOME/.deno}"
+deno_install="${DENO_INSTALL_ROOT:-$HOME/.deno}"
 bin_dir="$deno_install/bin"
 exe="$bin_dir/deno"
 
@@ -45,7 +45,7 @@ if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"
 else
 	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
-	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
+	echo "  export DENO_INSTALL_ROOT=\"$deno_install\""
+	echo "  export PATH=\"\$DENO_INSTALL_ROOT/bin:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -15,13 +15,13 @@ Invoke-ScriptAnalyzer *.ps1 -EnableExit -Exclude PSAvoidAssignmentToAutomaticVar
 
 # Test that we can install the latest version at the default location.
 Remove-Item "~\.deno" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = ""
+$env:DENO_INSTALL_ROOT = ""
 .\install.ps1
 ~\.deno\bin\deno.exe --version
 
 # Test that we can install a specific version at a custom location.
 Remove-Item "~\deno-0.38.0" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = "$Home\deno-0.38.0"
+$env:DENO_INSTALL_ROOT = "$Home\deno-0.38.0"
 
 .\install.ps1 v0.38.0
 $DenoVersion = ~\deno-0.38.0\bin\deno.exe --version

--- a/install_test.sh
+++ b/install_test.sh
@@ -7,12 +7,12 @@ set -e
 
 # Test that we can install the latest version at the default location.
 rm -f ~/.deno/bin/deno
-unset DENO_INSTALL
+unset DENO_INSTALL_ROOT
 sh ./install.sh
 ~/.deno/bin/deno --version
 
 # Test that we can install a specific version at a custom location.
 rm -rf ~/deno-0.38.0
-export DENO_INSTALL="$HOME/deno-0.38.0"
+export DENO_INSTALL_ROOT="$HOME/deno-0.38.0"
 ./install.sh v0.38.0
 ~/deno-0.38.0/bin/deno --version | grep 0.38.0


### PR DESCRIPTION
According to the docs (https://deno.land/manual/tools/script_installer), the environment variable that controls where deno is installed is `DENO_INSTALL_ROOT`.