### PR TITLE
Updat the deno version to be installed with asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ choco install deno
 ```sh
 asdf plugin-add deno https://github.com/asdf-community/asdf-deno.git
 
-asdf install deno 0.38.0
+asdf install deno 1.0.0
 
 # Activate globally with:
-asdf global deno 0.38.0
+asdf global deno 1.0.0
 
 # Activate locally in the current folder with:
-asdf local deno 0.38.0
+asdf local deno 1.0.0
 ```
 
 **With [Scoop](https://github.com/lukesampson/scoop/wiki/Switching-Ruby-And-Python-Versions):**
 
 ```sh
 # Install a specific version of deno:
-scoop install deno@0.22.0
+scoop install deno@1.0.0
 
-# Switch to v0.22.0
-scoop reset deno@0.22.0
+# Switch to v1.0.0
+scoop reset deno@1.0.0
 
 # Switch to the latest version
 scoop reset deno


### PR DESCRIPTION
Changes:
- In the README, update the deno version to be installed with asdf to 1.0.0

Although the change is trivial and not any sort of deal breaker, felt it's good to have the docs updated. I can update the whole doc if the version is available in every other installation source. I have only tried asdf, so I am not aware of other sources. 

