### PR TITLE
Test both pwsh and powershell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: tests powershell
         if: matrix.os == 'windows-latest'
-        shell: pwsh
         run: ./install_test.ps1
 
+      - name: tests powershell core
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: ./install_test.ps1


### PR DESCRIPTION
Currently, we only test in PowerShell Core (`pwsh`) rather than normal Powershell which is what most users will be using.

We do have some specific functionality depending on which PowerShell edition is used:
https://github.com/denoland/deno_install/blob/master/install.ps1#L34

Therefore, I'd like to test both in CI.

cc @ry 