### PR TITLE
Re-enable sh lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: shfmt
         if: matrix.os == 'macOS-latest'
         run: |
-          brew install shfmt
+          brew install shfmt shellcheck
           shfmt -d .
 
       - name: tests shell

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ Darwin) target="x86_64-apple-darwin" ;;
 *) target="x86_64-unknown-linux-gnu" ;;
 esac
 
-if [ $(uname -m) != "x86_64" ]; then
+if [ "$(uname -m)" != "x86_64" ]; then
 	echo "Unsupported architecture $(uname -m). Only x64 binaries are available."
 	exit
 fi

--- a/install_test.sh
+++ b/install_test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Lint.
-# TODO(ry) shellcheck -s sh ./*.sh
+shellcheck -s sh ./*.sh
 
 # Test that we can install the latest version at the default location.
 rm -f ~/.deno/bin/deno


### PR DESCRIPTION
```
Line 12:
if [ $(uname -m) != "x86_64" ]; then
     ^-- SC2046: Quote this to prevent word splitting.
```