### PR TITLE
chore: Adds asdf instructions for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,22 @@ yay -S deno-bin
 **With [asdf](https://asdf-vm.com) and [asdf-deno](https://github.com/asdf-community/asdf-deno):**
 
 ```sh
-asdf plugin-add deno https://github.com/asdf-community/asdf-deno.git
+asdf plugin add deno
 
+# Get latest version of deno available
+DENO_LATEST=$(asdf latest deno)
+
+asdf install deno $DENO_LATEST
+
+# Activate globally with:
+asdf global deno $DENO_LATEST
+
+# Activate locally in the current folder with:
+asdf local deno $DENO_LATEST
+
+#======================================================
+# If you want to install specific version of deno then use that version instead
+# of DENO_LATEST variable example
 asdf install deno 1.0.0
 
 # Activate globally with:


### PR DESCRIPTION
Added instructions to install latest version of deno instead of specific
version as that would be more common use case.

Removed deno plugin url in `plugin add` command as `deno` is available
in `asdf` plugin list