### PR TITLE
Fix PowerShell usage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: tests powershell
         if: matrix.os == 'windows-latest'
+        shell: powershell
         run: ./install_test.ps1
 
       - name: tests powershell core


### PR DESCRIPTION
As can be seen in the CI log, PowerShell Core was used twice instead of PowerShell and PowerShell Core.

https://github.com/denoland/deno_install/runs/718526050

```
tests powershell:
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"

tests powershell core:
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
```

This is despite the GitHub Actions documentation saying that "_[PowerShell is the] default shell used on Windows. The Desktop PowerShell. GitHub appends the extension .ps1 to your script name._"

https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions

This PR attempts to fix this issue by explicitly specifying `shell: powershell`.
