### PR TITLE
Don't expand DENO_INSTALL and PATH variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,6 @@ else
 	esac
 	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"$DENO_INSTALL/bin:$PATH\""
+	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi


### PR DESCRIPTION
Originally, the code looked like this:

https://github.com/denoland/deno_install/blob/af964a00050d02a0155044f5fe1bf7a94c5bf716/install.sh#L57

This would produce the following output: https://github.com/denoland/deno_install/runs/724640137

```
Deno was installed successfully to /home/runner/deno-1.0.0/bin/deno
Manually add the directory to your $HOME/.bash_profile (or similar)
  export DENO_INSTALL="/home/runner/deno-1.0.0"
  export PATH="$DENO_INSTALL/bin:$PATH"
Run '/home/runner/deno-1.0.0/bin/deno --help' to get started
```

With https://github.com/denoland/deno_install/pull/92, it was changed to:

https://github.com/denoland/deno_install/blob/73ac1a805f517799213a8c757429b1755609273e/install.sh#L61

It the meantime, there had been another PR which added `shellcheck`.

Now the code failed linting in CI because of a false positive by `shellcheck`: https://github.com/denoland/deno_install/runs/724641122

```
In ./install.sh line 61:
	echo '  export PATH="$DENO_INSTALL/bin:$PATH"'
             ^-- SC2016: Expressions don't expand in single quotes, use double quotes for that.
```

Note that the expression was not supposed to be expanded, hence the single quotes.

To fix CI, @bartlomieju followed `shellcheck`'s advice and used double quotes:

https://github.com/denoland/deno_install/blob/c92645cdeae4f157798131b0b9cc18960abdf568/install.sh#L61

However, the variables are being expanded now, so the script output looks like this:

```
Deno was installed successfully to /home/runner/.deno/bin/deno
Manually add the directory to your $HOME/.bash_profile (or similar)
  export DENO_INSTALL="/home/runner/.deno"
  export PATH="/bin:/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin"
Run '/home/runner/.deno/bin/deno --help' to get started
```

This PR restores the previous output by escaping the `$`-signs to prevent variable expansion.