### PR TITLE
Remove redundant 'v' in PowerShell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.0
 **With PowerShell:**
 
 ```powershell
-$v="v1.0.0"; iwr https://deno.land/x/install/install.ps1 -useb | iex
+$v="1.0.0"; iwr https://deno.land/x/install/install.ps1 -useb | iex
 ```
 
 ## Install via Package Manager

--- a/install.ps1
+++ b/install.ps1
@@ -39,7 +39,7 @@ $DenoUri = if (!$v) {
       Select-Object -First 1
   }
 } else {
-  "https://github.com/denoland/deno/releases/download/${v}/deno-${Target}.zip"
+  "https://github.com/denoland/deno/releases/download/v${v}/deno-${Target}.zip"
 }
 
 if (!(Test-Path $BinDir)) {

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -12,7 +12,7 @@ $env:DENO_INSTALL = ""
 Remove-Item "~\deno-1.0.0" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.0"
 
-$v = "v1.0.0"; .\install.ps1
+$v="1.0.0"; .\install.ps1
 $DenoVersion = ~\deno-1.0.0\bin\deno.exe --version
 if (!($DenoVersion -like '*1.0.0*')) {
   throw $DenoVersion


### PR DESCRIPTION
```diff
- $v="v1.0.0"
+ $v="1.0.0"
```

cc @bartlomieju - What do you think?