### PR TITLE
Support unzipping on Windows 8.1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -47,7 +47,17 @@ if (!(Test-Path $BinDir)) {
 }
 
 Invoke-WebRequest $DenoUri -OutFile $DenoZip -UseBasicParsing
-Expand-Archive $DenoZip -Destination $BinDir -Force
+
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive $DenoZip -Destination $BinDir -Force
+} else {
+  if (Test-Path $DenoExe) {
+    Remove-Item $DenoExe
+  }
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [IO.Compression.ZipFile]::ExtractToDirectory($DenoZip, $BinDir)
+}
+
 Remove-Item $DenoZip
 
 $User = [EnvironmentVariableTarget]::User


### PR DESCRIPTION
Fixes #146.

Tested manually on Windows 10 by commenting the `Expand-Archive` block...

cc @ry @bartlomieju 