### PR TITLE
Add support for shell installation on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*       text=auto
+*.sh    text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,16 @@ jobs:
           brew install shfmt shellcheck
           shfmt -d .
 
+      - name: shellcheck
+        if: matrix.os == 'windows-latest'
+        run: |
+          curl -LO https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.zip
+          mkdir ~/.shellcheck
+          unzip shellcheck-stable.zip -d ~/.shellcheck
+          mv ~/.shellcheck/shellcheck-stable.exe ~/.shellcheck/shellcheck.exe
+          echo "::add-path::$HOME/.shellcheck"
+
       - name: tests shell
-        if: matrix.os != 'windows-latest'
         shell: bash
         run: ./install_test.sh
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ scoop reset deno
 
 ## Compatibility
 
-- The Shell installer can be used on Windows via the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).
+- The Shell installer can be used on Windows with [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about), [MSYS](https://www.msys2.org) or equivalent set of tools.
 
 ## Known Issues
 

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,14 @@ if ! command -v unzip >/dev/null; then
 	exit 1
 fi
 
-case $(uname -s) in
-Darwin) target="x86_64-apple-darwin" ;;
-*) target="x86_64-unknown-linux-gnu" ;;
-esac
+if [ "$OS" = "Windows_NT" ]; then
+	target="x86_64-pc-windows-msvc"
+else
+	case $(uname -s) in
+	Darwin) target="x86_64-apple-darwin" ;;
+	*) target="x86_64-unknown-linux-gnu" ;;
+	esac
+fi
 
 if [ $# -eq 0 ]; then
 	deno_asset_path=$(


### PR DESCRIPTION
This adds support for installing the Windows version of Deno from the
shell script which should work as long as the user has a basic UNIX like
environment (MSYS, WSL, MingW, et cetera).

It works for GitHub runners as-well which means there's less friction in
setting up a test matrix which installs Deno.

This resolves #68 and closes #107 