### PR TITLE
Add support for Macports macOS package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ scoop install deno
 brew install deno
 ```
 
+**With [Macports](https://ports.macports.org/port/deno/summary):**
+
+```sh
+sudo port install deno
+```
+
 **With [Chocolatey](https://chocolatey.org/packages/deno):**
 
 ```powershell


### PR DESCRIPTION
There's other and older package manager for macOS (OS X) where deno has its maintained port