### PR TITLE
fix(install.sh): Use "unzip -d" instead of changing directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,7 @@ if [ ! -d "$bin_dir" ]; then
 fi
 
 curl --fail --location --progress-bar --output "$exe.zip" "$deno_uri"
-cd "$bin_dir"
-unzip -o "$exe.zip"
+unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -17,6 +17,15 @@ if (!($DenoVersion -like '*1.0.0*')) {
   throw $DenoVersion
 }
 
+# Test that we can install at a relative custom location.
+Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
+$env:DENO_INSTALL = "."
+$v = "1.1.0"; .\install.ps1
+$DenoVersion = bin\deno.exe --version
+if (!($DenoVersion -like '*1.1.0*')) {
+  throw $DenoVersion
+}
+
 # Test that the old temp file installer still works.
 Remove-Item "~\deno-1.0.1" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.1"

--- a/install_test.sh
+++ b/install_test.sh
@@ -16,3 +16,8 @@ rm -rf ~/deno-1.0.0
 export DENO_INSTALL="$HOME/deno-1.0.0"
 ./install.sh v1.0.0
 ~/deno-1.0.0/bin/deno --version | grep 1.0.0
+
+# Test that we can install at a relative custom location.
+export DENO_INSTALL="."
+./install.sh v1.1.0
+bin/deno --version | grep 1.1.0


### PR DESCRIPTION
Fixes `DENO_INSTALL=<relative path>` for the shell installer.