### PR TITLE
Use GITHUB_PATH instead of add-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir ~/.shellcheck
           unzip shellcheck-stable.zip -d ~/.shellcheck
           mv ~/.shellcheck/shellcheck-stable.exe ~/.shellcheck/shellcheck.exe
-          echo "::add-path::$HOME/.shellcheck"
+          echo "${HOME}/.shellcheck" >> ${GITHUB_PATH}
 
       - name: tests shell
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir ~/.shellcheck
           unzip shellcheck-stable.zip -d ~/.shellcheck
           mv ~/.shellcheck/shellcheck-stable.exe ~/.shellcheck/shellcheck.exe
-          echo "${HOME}/.shellcheck" >> ${GITHUB_PATH}
+          echo "$HOME/.shellcheck" >> $env:GITHUB_PATH
 
       - name: tests shell
         shell: bash


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.