### PR TITLE
Add `Deno` to path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,10 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
+echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.bash_profile
+echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.zshrc
+echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.bashrc
+
 echo "Deno was installed successfully to $exe"
 if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,10 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
+touch -p "\$HOME/.bash_profile"
+touch -p "\$HOME/.zshrc"
+touch -p "\$HOME/.bashrc"
+
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bash_profile"
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.zshrc"
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bashrc"

--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,9 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
-touch -p "\$HOME/.bash_profile"
-touch -p "\$HOME/.zshrc"
-touch -p "\$HOME/.bashrc"
+touch "\$HOME/.bash_profile"
+touch "\$HOME/.zshrc"
+touch "\$HOME/.bashrc"
 
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bash_profile"
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.zshrc"

--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,9 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
-echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.bash_profile
-echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.zshrc
-echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.bashrc
+echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bash_profile"
+echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.zshrc"
+echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bashrc"
 
 echo "Deno was installed successfully to $exe"
 if command -v deno >/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,9 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
-echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.bash_profile
-echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.zshrc
-echo 'export PATH=$HOME/.deno/bin:$PATH' >>$HOME/.bashrc
+echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.bash_profile
+echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.zshrc
+echo "export PATH=$HOME/.deno/bin:$PATH" >>$HOME/.bashrc
 
 echo "Deno was installed successfully to $exe"
 if command -v deno >/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,6 @@ unzip -d "$bin_dir" -o "$exe.zip"
 chmod +x "$exe"
 rm "$exe.zip"
 
-touch "\$HOME/.bash_profile"
-touch "\$HOME/.zshrc"
-touch "\$HOME/.bashrc"
-
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bash_profile"
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.zshrc"
 echo "export PATH=$HOME/.deno/bin:$PATH" >>"\$HOME/.bashrc"


### PR DESCRIPTION
When you install deno on MacOS, you have to manually add Deno to path. with the change that I have proposed, Deno will add itself to the PATH to the files(like .bash_profile, .bashrc, .zshrc) which are loaded when any terminal is launched