### PR TITLE
[PowerShell] : Use of `param` for a more standard use of parameters

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@
 # Copyright 2018 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
-$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = "Stop"
 
 if ($v) {
   $Version = "v${v}"
@@ -20,7 +20,7 @@ $BinDir = if ($DenoInstall) {
 
 $DenoZip = "$BinDir\deno.zip"
 $DenoExe = "$BinDir\deno.exe"
-$Target = 'x86_64-pc-windows-msvc'
+$Target = "x86_64-pc-windows-msvc"
 
 # GitHub requires TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -50,9 +50,9 @@ if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
 Remove-Item $DenoZip
 
 $User = [EnvironmentVariableTarget]::User
-$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+$Path = [Environment]::GetEnvironmentVariable("Path", $User)
 if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
-  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
+  [Environment]::SetEnvironmentVariable("Path", "$Path;$BinDir", $User)
   $Env:Path += ";$BinDir"
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -2,18 +2,18 @@
 # Copyright 2018 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
+param(
+  [String]$Version = "latest" # This is the default value for the version parameter
+)
+
 $ErrorActionPreference = "Stop"
 
-if ($v) {
-  $Version = "v${v}"
-}
-if ($args.Length -eq 1) {
-  $Version = $args.Get(0)
-}
+# Support the legacy $v
+if($v) {$Version = $v}
 
-$DenoInstall = $env:DENO_INSTALL
-$BinDir = if ($DenoInstall) {
-  "$DenoInstall\bin"
+
+$BinDir = if ($env:DENO_INSTALL) {
+  "$env:DENO_INSTALL\bin"
 } else {
   "$Home\.deno\bin"
 }
@@ -25,7 +25,10 @@ $Target = "x86_64-pc-windows-msvc"
 # GitHub requires TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$DenoUri = if (!$Version) {
+# Set Version to v\d.\d.\d if a \d.\d.\d value is entered
+$Version = if($Version -match "^(\d{1,}\.){2}\d{1,}$") {"v$Version"} else {$Version}
+
+$DenoUri = if ($Version -eq "latest") {
   "https://github.com/denoland/deno/releases/latest/download/deno-${Target}.zip"
 } else {
   "https://github.com/denoland/deno/releases/download/${Version}/deno-${Target}.zip"
@@ -56,5 +59,5 @@ if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
   $Env:Path += ";$BinDir"
 }
 
-Write-Output "Deno was installed successfully to $DenoExe"
-Write-Output "Run 'deno --help' to get started"
+Write-Host -ForeGroundColor Green "Deno was installed successfully to $DenoExe"
+Write-Host "Run 'deno --help' to get started"

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -1,36 +1,84 @@
 #!/usr/bin/env pwsh
 
+
 $ErrorActionPreference = "Stop"
+#Hide the progressbar when testing
+$ProgressPreference = "SilentlyContinue"
+
+Write-Host -ForeGroundColor Yellow "---ENV---"
+$PSVersionTable
+Write-Host -ForeGroundColor Yellow "`n---ENV---`n"
 
 # Test that we can install the latest version at the default location.
+# Case 1 : Using no parameter
+
+Write-Host -ForeGroundColor Yellow "Test that we can install the latest version at the default location."
+Write-Host -ForeGroundColor Yellow "Case 1 : Using no parameter`n"
+
 Remove-Item "~\.deno" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = ""
-$v = $null; .\install.ps1
+.\install.ps1 
+~\.deno\bin\deno.exe --version
+
+# Test that we can install the latest version at the default location.
+# Case 2 : Using latest as the $Version value
+
+Write-Host -ForeGroundColor Yellow "`nTest that we can install the latest version at the default location."
+Write-Host -ForeGroundColor Yellow "Case 2 : Using latest as the `$Version value`n"
+
+Remove-Item "~\.deno" -Recurse -Force -ErrorAction SilentlyContinue
+$env:DENO_INSTALL = ""
+.\install.ps1 -Version "latest"
 ~\.deno\bin\deno.exe --version
 
 # Test that we can install a specific version at a custom location.
-Remove-Item "~\deno-1.0.0" -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host -ForeGroundColor Yellow "`nTest that we can install a specific version at a custom location.`n"
+
+Remove-Item "$Home\deno-1.0.0" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.0"
-$v = "1.0.0"; .\install.ps1
+.\install.ps1 -Version "v1.0.0"
 $DenoVersion = ~\deno-1.0.0\bin\deno.exe --version
+$DenoVersion
 if (!($DenoVersion -like "*1.0.0*")) {
   throw $DenoVersion
 }
 
 # Test that we can install at a relative custom location.
-Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host -ForeGroundColor Yellow "`nTest that we can install at a relative custom location.`n"
+
+Remove-Item ".\bin" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "."
-$v = "1.1.0"; .\install.ps1
-$DenoVersion = bin\deno.exe --version
+.\install.ps1 -Version "v1.1.0"
+$DenoVersion = .\bin\deno.exe --version
+$DenoVersion
+if (!($DenoVersion -like "*1.1.0*")) {
+  throw $DenoVersion
+}
+
+# Test that the $v method of installing still works
+
+Write-Host -ForeGroundColor Yellow "`nTest that the `$v method of installing still works`n"
+
+Remove-Item ".\bin" -Recurse -Force -ErrorAction SilentlyContinue
+$env:DENO_INSTALL = "."
+$v = "v1.1.0"; .\install.ps1
+$DenoVersion = .\bin\deno.exe --version
+$DenoVersion
 if (!($DenoVersion -like "*1.1.0*")) {
   throw $DenoVersion
 }
 
 # Test that the old temp file installer still works.
+
+Write-Host -ForeGroundColor Yellow "`nTest that the old temp file installer still works.`n"
+
 Remove-Item "~\deno-1.0.1" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.1"
 $v = $null; .\install.ps1 v1.0.1
 $DenoVersion = ~\deno-1.0.1\bin\deno.exe --version
+$DenoVersion
 if (!($DenoVersion -like "*1.0.1*")) {
   throw $DenoVersion
 }

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = "Stop"
 
 # Test that we can install the latest version at the default location.
 Remove-Item "~\.deno" -Recurse -Force -ErrorAction SilentlyContinue
@@ -13,7 +13,7 @@ Remove-Item "~\deno-1.0.0" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.0"
 $v = "1.0.0"; .\install.ps1
 $DenoVersion = ~\deno-1.0.0\bin\deno.exe --version
-if (!($DenoVersion -like '*1.0.0*')) {
+if (!($DenoVersion -like "*1.0.0*")) {
   throw $DenoVersion
 }
 
@@ -22,7 +22,7 @@ Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "."
 $v = "1.1.0"; .\install.ps1
 $DenoVersion = bin\deno.exe --version
-if (!($DenoVersion -like '*1.1.0*')) {
+if (!($DenoVersion -like "*1.1.0*")) {
   throw $DenoVersion
 }
 
@@ -31,6 +31,6 @@ Remove-Item "~\deno-1.0.1" -Recurse -Force -ErrorAction SilentlyContinue
 $env:DENO_INSTALL = "$Home\deno-1.0.1"
 $v = $null; .\install.ps1 v1.0.1
 $DenoVersion = ~\deno-1.0.1\bin\deno.exe --version
-if (!($DenoVersion -like '*1.0.1*')) {
+if (!($DenoVersion -like "*1.0.1*")) {
   throw $DenoVersion
 }


### PR DESCRIPTION
Hello,

The `install.ps1` script now uses the `-Version` parameter instead of the `$v`.
`$v` still works, A test was added to check for it.

The script can now be run as : 

```powershell
.\install.ps1 -Version "1.0.0"
# or
.\install.ps1 -Version "v1.0.0"
# or
.\install.ps1 -Version "latest" # $Version default to latest
```

This command should still run fine :

```powershell
$v="1.0.0"; .\install.ps1   
```

Test have been run with two differents versions of Powershell : 

- Using Windows Powershell 5.1

```
---ENV---

Name                           Value
----                           -----
PSVersion                      5.1.19041.906
PSEdition                      Desktop
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
BuildVersion                   10.0.19041.906
CLRVersion                     4.0.30319.42000
WSManStackVersion              3.0
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1

---ENV---

Test that we can install the latest version at the default location.
Case 1 : Using no parameter

Deno was installed successfully to C:\Users\benoit\.deno\bin\deno.exe
Run 'deno --help' to get started
deno 1.10.1 (release, x86_64-pc-windows-msvc)
v8 9.1.269.27
typescript 4.2.2

Test that we can install the latest version at the default location.
Case 2 : Using latest as the $Version value

Deno was installed successfully to C:\Users\benoit\.deno\bin\deno.exe
Run 'deno --help' to get started
deno 1.10.1 (release, x86_64-pc-windows-msvc)
v8 9.1.269.27
typescript 4.2.2

Test that we can install a specific version at a custom location.

Deno was installed successfully to C:\Users\benoit\deno-1.0.0\bin\deno.exe
Run 'deno --help' to get started
deno 1.0.0
v8 8.4.300
typescript 3.9.2

Test that we can install at a relative custom location.

Deno was installed successfully to .\bin\deno.exe
Run 'deno --help' to get started
deno 1.1.0
v8 8.4.300
typescript 3.9.2

Test that the $v method of installing still works

Deno was installed successfully to .\bin\deno.exe
Run 'deno --help' to get started
deno 1.1.0
v8 8.4.300
typescript 3.9.2

Test that the old temp file installer still works.

Deno was installed successfully to C:\Users\benoit\deno-1.0.1\bin\deno.exe
Run 'deno --help' to get started
deno 1.0.1
v8 8.4.300
typescript 3.9.2
```

- Using Powershell 7.1.3 on Windows

```
---ENV---

Name                           Value
----                           -----
PSVersion                      7.1.3
PSEdition                      Core
GitCommitId                    7.1.3
OS                             Microsoft Windows 10.0.19042
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}       
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

---ENV---

Test that we can install the latest version at the default location.
Case 1 : Using no parameter

Deno was installed successfully to C:\Users\benoit\.deno\bin\deno.exe
Run 'deno --help' to get started
deno 1.10.1 (release, x86_64-pc-windows-msvc)
v8 9.1.269.27
typescript 4.2.2

Test that we can install the latest version at the default location.
Case 2 : Using latest as the $Version value

Deno was installed successfully to C:\Users\benoit\.deno\bin\deno.exe
Run 'deno --help' to get started
deno 1.10.1 (release, x86_64-pc-windows-msvc)
v8 9.1.269.27
typescript 4.2.2

Test that we can install a specific version at a custom location.

Deno was installed successfully to C:\Users\benoit\deno-1.0.0\bin\deno.exe
Run 'deno --help' to get started
deno 1.0.0
v8 8.4.300
typescript 3.9.2

Test that we can install at a relative custom location.

Deno was installed successfully to .\bin\deno.exe
Run 'deno --help' to get started
deno 1.1.0
v8 8.4.300
typescript 3.9.2

Test that the $v method of installing still works

Deno was installed successfully to .\bin\deno.exe
Run 'deno --help' to get started
deno 1.1.0
v8 8.4.300
typescript 3.9.2

Test that the old temp file installer still works.

Deno was installed successfully to C:\Users\benoit\deno-1.0.1\bin\deno.exe
Run 'deno --help' to get started
deno 1.0.1
v8 8.4.300
typescript 3.9.2
```

Tests use now colors in the console, they are more readable, and the progress bar is now hidden when running tests.
