### PR TITLE
Lint on MacOS only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
         uses: actions/checkout@v1
 
       - name: lint
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macOS-latest'
         run: |
+          brew install shfmt shellcheck
           shfmt -d .
           shellcheck -s sh *.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: shfmt
-        if: matrix.os == 'macOS-latest'
+      - name: lint
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          brew install shfmt shellcheck
           shfmt -d .
-
-      - name: shellcheck
-        if: matrix.os == 'windows-latest'
-        run: |
-          curl -LO https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.zip
-          mkdir ~/.shellcheck
-          unzip shellcheck-stable.zip -d ~/.shellcheck
-          mv ~/.shellcheck/shellcheck-stable.exe ~/.shellcheck/shellcheck.exe
-          echo "$HOME/.shellcheck" >> $env:GITHUB_PATH
+          shellcheck -s sh *.sh
 
       - name: tests shell
         shell: bash

--- a/install_test.sh
+++ b/install_test.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Lint.
-shellcheck -s sh ./*.sh
-
 # Test that we can install the latest version at the default location.
 rm -f ~/.deno/bin/deno
 unset DENO_INSTALL


### PR DESCRIPTION
`shfmt` and `shellcheck` are installed in `ubuntu-latest` in Github Actions by default. Since it's not necessary to run linting multiple times, I removed the `shfmt` and `shellcheck` installations for MacOS and Windows. Now linting is run only `if: matrix.os == 'ubuntu-latest'`.

This PR also fixes #185.

EDIT: Correction: `shfmt` is not installed by default in `ubuntu-latest`. I'm now installing `shfmt` and `shellcheck` via `brew` and running them on MacOS only.