### PR TITLE
Replace `DENO_INSTALL` with `DENO_INSTALL_ROOT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,21 +115,21 @@ scoop reset deno
 
 ## Environment Variables
 
-- `DENO_INSTALL` - The directory in which to install Deno. This defaults to
-  `$HOME/.deno`. The executable is placed in `$DENO_INSTALL/bin`. One
+- `DENO_INSTALL_ROOT` - The directory in which to install Deno. This defaults to
+  `$HOME/.deno`. The executable is placed in `$DENO_INSTALL_ROOT/bin`. One
   application of this is a system-wide installation:
 
   **With Shell (`/usr/local`):**
 
   ```sh
-  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh
+  curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL_ROOT=/usr/local sh
   ```
 
   **With PowerShell (`C:\Program Files\deno`):**
 
   ```powershell
   # Run as administrator:
-  $env:DENO_INSTALL = "C:\Program Files\deno"
+  $env:DENO_INSTALL_ROOT = "C:\Program Files\deno"
   iwr https://deno.land/x/install/install.ps1 -useb | iex
   ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@ if ($args.Length -eq 1) {
   $Version = $args.Get(0)
 }
 
-$DenoInstall = $env:DENO_INSTALL
+$DenoInstall = $env:DENO_INSTALL_ROOT
 $BinDir = if ($DenoInstall) {
   "$DenoInstall\bin"
 } else {

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ else
 	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno-${target}.zip"
 fi
 
-deno_install="${DENO_INSTALL:-$HOME/.deno}"
+deno_install="${DENO_INSTALL_ROOT:-$HOME/.deno}"
 bin_dir="$deno_install/bin"
 exe="$bin_dir/deno"
 
@@ -47,7 +47,7 @@ else
 	*) shell_profile=".bash_profile" ;;
 	esac
 	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
-	echo "  export DENO_INSTALL=\"$deno_install\""
-	echo "  export PATH=\"\$DENO_INSTALL/bin:\$PATH\""
+	echo "  export DENO_INSTALL_ROOT=\"$deno_install\""
+	echo "  export PATH=\"\$DENO_INSTALL_ROOT/bin:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -4,13 +4,13 @@ $ErrorActionPreference = 'Stop'
 
 # Test that we can install the latest version at the default location.
 Remove-Item "~\.deno" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = ""
+$env:DENO_INSTALL_ROOT = ""
 $v = $null; .\install.ps1
 ~\.deno\bin\deno.exe --version
 
 # Test that we can install a specific version at a custom location.
 Remove-Item "~\deno-1.0.0" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = "$Home\deno-1.0.0"
+$env:DENO_INSTALL_ROOT = "$Home\deno-1.0.0"
 $v = "1.0.0"; .\install.ps1
 $DenoVersion = ~\deno-1.0.0\bin\deno.exe --version
 if (!($DenoVersion -like '*1.0.0*')) {
@@ -19,7 +19,7 @@ if (!($DenoVersion -like '*1.0.0*')) {
 
 # Test that we can install at a relative custom location.
 Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = "."
+$env:DENO_INSTALL_ROOT = "."
 $v = "1.1.0"; .\install.ps1
 $DenoVersion = bin\deno.exe --version
 if (!($DenoVersion -like '*1.1.0*')) {
@@ -28,7 +28,7 @@ if (!($DenoVersion -like '*1.1.0*')) {
 
 # Test that the old temp file installer still works.
 Remove-Item "~\deno-1.0.1" -Recurse -Force -ErrorAction SilentlyContinue
-$env:DENO_INSTALL = "$Home\deno-1.0.1"
+$env:DENO_INSTALL_ROOT = "$Home\deno-1.0.1"
 $v = $null; .\install.ps1 v1.0.1
 $DenoVersion = ~\deno-1.0.1\bin\deno.exe --version
 if (!($DenoVersion -like '*1.0.1*')) {

--- a/install_test.sh
+++ b/install_test.sh
@@ -4,17 +4,17 @@ set -e
 
 # Test that we can install the latest version at the default location.
 rm -f ~/.deno/bin/deno
-unset DENO_INSTALL
+unset DENO_INSTALL_ROOT
 sh ./install.sh
 ~/.deno/bin/deno --version
 
 # Test that we can install a specific version at a custom location.
 rm -rf ~/deno-1.0.0
-export DENO_INSTALL="$HOME/deno-1.0.0"
+export DENO_INSTALL_ROOT="$HOME/deno-1.0.0"
 ./install.sh v1.0.0
 ~/deno-1.0.0/bin/deno --version | grep 1.0.0
 
 # Test that we can install at a relative custom location.
-export DENO_INSTALL="."
+export DENO_INSTALL_ROOT="."
 ./install.sh v1.1.0
 bin/deno --version | grep 1.1.0


### PR DESCRIPTION
 (denoland/deno#4787)

I’m not sure if this is intentional, but deno uses `DENO_INSTALL_ROOT`.