### PR TITLE
Third party build support for Linux ARM64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,17 +12,25 @@ fi
 if [ "$OS" = "Windows_NT" ]; then
 	target="x86_64-pc-windows-msvc"
 else
+	repository="denoland/deno"
 	case $(uname -sm) in
 	"Darwin x86_64") target="x86_64-apple-darwin" ;;
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
+	"Linux aarch64")
+		if [ "$1" != "-y" ] && [ "$2" != "-y" ]; then
+			echo "Error: Official Deno builds for Linux aarch64 are not available, by passing the '-y' flag third party builds can be installed.\n(Builds provided by: https://github.com/LukeChannings/deno-arm64)" 1>&2
+			exit 1
+		fi
+		repository="LukeChannings/deno-arm64"
+		target="linux-arm64" ;;
 	*) target="x86_64-unknown-linux-gnu" ;;
 	esac
 fi
 
-if [ $# -eq 0 ]; then
-	deno_uri="https://github.com/denoland/deno/releases/latest/download/deno-${target}.zip"
+if [ $# -eq 0 ] || [ "$1" = "-y" ]; then
+	deno_uri="https://github.com/${repository}/releases/latest/download/deno-${target}.zip"
 else
-	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno-${target}.zip"
+	deno_uri="https://github.com/${repository}/releases/download/${1}/deno-${target}.zip"
 fi
 
 deno_install="${DENO_INSTALL:-$HOME/.deno}"

--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,10 @@ if ! command -v unzip >/dev/null; then
 	exit 1
 fi
 
+repository="denoland/deno"
 if [ "$OS" = "Windows_NT" ]; then
 	target="x86_64-pc-windows-msvc"
 else
-	repository="denoland/deno"
 	case $(uname -sm) in
 	"Darwin x86_64") target="x86_64-apple-darwin" ;;
 	"Darwin arm64") target="aarch64-apple-darwin" ;;


### PR DESCRIPTION
Enable installation of third party builds by passing the '-y' flag to the script otherwise block installation on ARM64 systems.

Not sure if third party builds are considered safe for the official installer, but I'd like to propose this solution to issues with the install script on ARM64 systems.
The default behaviour is to block the installation on ARM64 and printing out an error message which points out that official binaries are not available. But if the user specifies the `-y`-argument and agrees to use third party builds they can use the install script to deploy the binaries built by @LukeChannings to their system.

_PS: I'm using these builds for over a year without any trouble, that's why I think its a good idea to make them available official as an alternative._

this fixes #199