### PR TITLE
Block installation on arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,8 @@ else
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
 	"Linux aarch64")
 		echo "Error: Official Deno builds for Linux aarch64 are not available. (https://github.com/denoland/deno/issues/1846)" 1>&2
-		exit 1 ;;
+		exit 1
+		;;
 	*) target="x86_64-unknown-linux-gnu" ;;
 	esac
 fi

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,9 @@ else
 	case $(uname -sm) in
 	"Darwin x86_64") target="x86_64-apple-darwin" ;;
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
+	"Linux aarch64")
+		echo "Error: Official Deno builds for Linux aarch64 are not available. (https://github.com/denoland/deno/issues/1846)" 1>&2
+		exit 1 ;;
 	*) target="x86_64-unknown-linux-gnu" ;;
 	esac
 fi


### PR DESCRIPTION
do not proceed the install process on arm64 hardware

follow up PR to #209, but just with the code what quits the install script when it detects arm64 architecture (also references the issue to this topic). This fixes #199 