### PR TITLE
fix: Use .bashrc instead of .bash_profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if command -v deno >/dev/null; then
 else
 	case $SHELL in
 	/bin/zsh) shell_profile=".zshrc" ;;
-	*) shell_profile=".bash_profile" ;;
+	*) shell_profile=".bashrc" ;;
 	esac
 	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
 	echo "  export DENO_INSTALL=\"$deno_install\""


### PR DESCRIPTION
Closes https://github.com/denoland/vscode_deno/issues/392.

`.bash_profile` is under some circumstances not loaded by VSCode's extension host, making it fail to find `deno` if that's where the env setup is. `.bashrc` is more common.