### PR TITLE
Misc refactorings

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
-# Copyright 2022 the Deno authors. All rights reserved. MIT license.
+# Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
 $ErrorActionPreference = 'Stop'

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
-# Copyright 2018 the Deno authors. All rights reserved. MIT license.
+# Copyright 2022 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
 $ErrorActionPreference = 'Stop'
@@ -7,25 +7,22 @@ $ErrorActionPreference = 'Stop'
 if ($v) {
   $Version = "v${v}"
 }
-if ($args.Length -eq 1) {
-  $Version = $args.Get(0)
+if ($Args.Length -eq 1) {
+  $Version = $Args.Get(0)
 }
 
 $DenoInstall = $env:DENO_INSTALL
 $BinDir = if ($DenoInstall) {
-  "$DenoInstall\bin"
+  "${DenoInstall}\bin"
 } else {
-  "$Home\.deno\bin"
+  "${Home}\.deno\bin"
 }
 
 $DenoZip = "$BinDir\deno.zip"
 $DenoExe = "$BinDir\deno.exe"
 $Target = 'x86_64-pc-windows-msvc'
 
-# GitHub requires TLS 1.2
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-$DenoUri = if (!$Version) {
+$DownloadUrl = if (!$Version) {
   "https://github.com/denoland/deno/releases/latest/download/deno-${Target}.zip"
 } else {
   "https://github.com/denoland/deno/releases/download/${Version}/deno-${Target}.zip"
@@ -35,18 +32,18 @@ if (!(Test-Path $BinDir)) {
   New-Item $BinDir -ItemType Directory | Out-Null
 }
 
-curl.exe -Lo $DenoZip $DenoUri
+curl.exe -Lo $DenoZip $DownloadUrl
 
 tar.exe xf $DenoZip -C $BinDir
 
 Remove-Item $DenoZip
 
-$User = [EnvironmentVariableTarget]::User
-$Path = [Environment]::GetEnvironmentVariable('Path', $User)
-if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
-  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
-  $Env:Path += ";$BinDir"
+$User = [System.EnvironmentVariableTarget]::User
+$Path = [System.Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";${Path};".ToLower() -like "*;${BinDir};*".ToLower())) {
+  [System.Environment]::SetEnvironmentVariable('Path', "${Path};${BinDir}", $User)
+  $Env:Path += ";${BinDir}"
 }
 
-Write-Output "Deno was installed successfully to $DenoExe"
+Write-Output "Deno was installed successfully to ${DenoExe}"
 Write-Output "Run 'deno --help' to get started"


### PR DESCRIPTION
- Update copyright year
- Consistently capitalize first character of all variables (except `$v`)
- Consistently use `${VariableName}` instead of `$VariableName` for variable inserts in strings
- Remove old, unnecessary code for using TLS 1.2 in .NET (no longer necessary since we use `curl` for the download now)
- Use fully qualified namespaces  (e. g. `[System.Environment]` instead of `[Environment]`) to make it easier to Google and review the code
- Rename `$DenoUri` to `$DownloadUrl`