### PR TITLE
Support `7z` besides `unzip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ scoop reset deno
 
 ### either unzip or 7z is required
 
-The program [`unzip`](https://linux.die.net/man/1/unzip) or [`7z`](https://linux.die.net/man/1/7z) is a requirement for the Shell installer.
+To decompress the `deno` archive, one of either [`unzip`](https://linux.die.net/man/1/unzip) or [`7z`](https://linux.die.net/man/1/7z) must be available on the target system.
 
 ```sh
 $ curl -fsSL https://deno.land/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -151,18 +151,18 @@ scoop reset deno
 
 ## Known Issues
 
-### unzip is required
+### either unzip or 7z is required
 
-The program [`unzip`](https://linux.die.net/man/1/unzip) is a requirement for the Shell installer.
+The program [`unzip`](https://linux.die.net/man/1/unzip) or [`7z`](https://linux.die.net/man/1/7z) is a requirement for the Shell installer.
 
 ```sh
 $ curl -fsSL https://deno.land/install.sh | sh
-Error: unzip is required to install Deno (see: https://github.com/denoland/deno_install#unzip-is-required).
+Error: either unzip or 7z is required to install Deno (see: https://github.com/denoland/deno_install#either-unzip-or-7z-is-required ).
 ```
 
 **When does this issue occur?**
 
-During the `install.sh` process, `unzip` is used to extract the zip archive.
+During the `install.sh` process, `unzip` or `7z` is used to extract the zip archive.
 
 **How can this issue be fixed?**
 

--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,10 @@ if [ ! -d "$bin_dir" ]; then
 fi
 
 curl --fail --location --progress-bar --output "$exe.zip" "$deno_uri"
-if command -v 7z >/dev/null; then
-	7z x -o"$bin_dir" -y "$exe.zip"
-else
+if command -v unzip >/dev/null; then
 	unzip -d "$bin_dir" -o "$exe.zip"
+else
+	7z x -o"$bin_dir" -y "$exe.zip"
 fi
 chmod +x "$exe"
 rm "$exe.zip"

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-if ! command -v unzip >/dev/null; then
-	echo "Error: unzip is required to install Deno (see: https://github.com/denoland/deno_install#unzip-is-required )." 1>&2
+if ! command -v unzip >/dev/null && ! command -v 7z >/dev/null; then
+	echo "Error: either unzip or 7z is required to install Deno (see: https://github.com/denoland/deno_install#either-unzip-or-7z-is-required )." 1>&2
 	exit 1
 fi
 
@@ -38,7 +38,11 @@ if [ ! -d "$bin_dir" ]; then
 fi
 
 curl --fail --location --progress-bar --output "$exe.zip" "$deno_uri"
-unzip -d "$bin_dir" -o "$exe.zip"
+if command -v 7z >/dev/null; then
+	7z x -o"$bin_dir" -y "$exe.zip"
+else
+	unzip -d "$bin_dir" -o "$exe.zip"
+fi
 chmod +x "$exe"
 rm "$exe.zip"
 


### PR DESCRIPTION
Now *install.sh* works if either `unzip` or `7z` is available.  There are people who prefer `7z` over `unzip` even for extracting ZIP files so that they are not willing to install `unzip` besides `7z`.  This change could make such people happy.  Furthermore, there are some minimal Linux distributions that ship with only `7z` (e.g., Synology DSM).