### PR TITLE
refactor: use dl.deno.land to download binary

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -22,11 +22,13 @@ $DenoZip = "$BinDir\deno.zip"
 $DenoExe = "$BinDir\deno.exe"
 $Target = 'x86_64-pc-windows-msvc'
 
-$DownloadUrl = if (!$Version) {
-  "https://github.com/denoland/deno/releases/latest/download/deno-${Target}.zip"
+$Version = if (!$Version) {
+  curl.exe -s "https://dl.deno.land/release-latest.txt"  
 } else {
-  "https://github.com/denoland/deno/releases/download/${Version}/deno-${Target}.zip"
+  $Version
 }
+
+$DownloadUrl = "https://dl.deno.land/release/${Version}/deno-${Target}.zip"
 
 if (!(Test-Path $BinDir)) {
   New-Item $BinDir -ItemType Directory | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -21,11 +21,12 @@ else
 fi
 
 if [ $# -eq 0 ]; then
-	deno_uri="https://github.com/denoland/deno/releases/latest/download/deno-${target}.zip"
+	deno_version="$(curl -s https://dl.deno.land/release-latest.txt)"
 else
-	deno_uri="https://github.com/denoland/deno/releases/download/${1}/deno-${target}.zip"
+	deno_version=$1
 fi
 
+deno_uri="https://dl.deno.land/release/${deno_version}/deno-${target}.zip"
 deno_install="${DENO_INSTALL:-$HOME/.deno}"
 bin_dir="$deno_install/bin"
 exe="$bin_dir/deno"

--- a/install_test.sh
+++ b/install_test.sh
@@ -9,12 +9,12 @@ sh ./install.sh
 ~/.deno/bin/deno --version
 
 # Test that we can install a specific version at a custom location.
-rm -rf ~/deno-1.0.0
-export DENO_INSTALL="$HOME/deno-1.0.0"
-./install.sh v1.0.0
-~/deno-1.0.0/bin/deno --version | grep 1.0.0
+rm -rf ~/deno-1.15.0
+export DENO_INSTALL="$HOME/deno-1.15.0"
+./install.sh v1.15.0
+~/deno-1.15.0/bin/deno --version | grep 1.15.0
 
 # Test that we can install at a relative custom location.
 export DENO_INSTALL="."
-./install.sh v1.1.0
-bin/deno --version | grep 1.1.0
+./install.sh v1.46.0
+bin/deno --version | grep 1.46.0


### PR DESCRIPTION
This effectively adds support for installing RC binaries.

Closes https://github.com/denoland/deno_install/issues/293