### PR TITLE
fix: handle stdin when piping to sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,4 +20,6 @@ jobs:
           deno-version: rc
 
       - name: Publish to JSR on tag
-        run: deno run -A jsr:@david/publish-on-tag@0.1.3
+        run: |
+          cd shell-setup
+          deno run -A jsr:@david/publish-on-tag@0.1.3

--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,20 @@ chmod +x "$exe"
 rm "$exe.zip"
 
 echo "Deno was installed successfully to $exe"
-if $exe eval 'const [major, minor] = Deno.version.deno.split("."); if (major < 2 && minor < 42) Deno.exit(1)'; then
+
+run_shell_setup() {
 	$exe run -A jsr:@deno/installer-shell-setup/bundled "$deno_install"
+
+}
+# If stdout is a terminal, see if we can run shell setup script (which includes interactive prompts)
+if [ -t 1 ] && $exe eval 'const [major, minor] = Deno.version.deno.split("."); if (major < 2 && minor < 42) Deno.exit(1)'; then
+	if [ -t 0 ]; then
+		run_shell_setup
+	else
+		# This script is probably running piped into sh, so we don't have direct access to stdin.
+		# Instead, explicitly connect /dev/tty to stdin
+		run_shell_setup </dev/tty
+	fi
 fi
 if command -v deno >/dev/null; then
 	echo "Run 'deno --help' to get started"


### PR DESCRIPTION
When you run the install script piped to sh, stdin isn't interactive, so it can't be used for interactive prompts (and so the shell setup script just bails out).

Instead, set up stdin as `/dev/tty` if necessary.