### PR TITLE
fix: Do not prompt if CI env var is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ run_shell_setup() {
 
 }
 # If stdout is a terminal, see if we can run shell setup script (which includes interactive prompts)
-if [ -t 1 ] && $exe eval 'const [major, minor] = Deno.version.deno.split("."); if (major < 2 && minor < 42) Deno.exit(1)'; then
+if [ -z "$CI" ] && [ -t 1 ] && $exe eval 'const [major, minor] = Deno.version.deno.split("."); if (major < 2 && minor < 42) Deno.exit(1)'; then
 	if [ -t 0 ]; then
 		run_shell_setup
 	else


### PR DESCRIPTION
While I'm also working on https://github.com/denoland/deno_install/issues/297 (a way to accept defaults, outside of a CI environment), this should fix most CI issues people are running into, and is an easy change.