### PR TITLE
chore: fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,6 @@ jobs:
       - name: integration tests
         if: matrix.os != 'windows-latest'
         run: deno test -A --permit-no-files
+      
+      - name: dry run publishing
+        run: deno publish --dry-run

--- a/shell-setup/deno.json
+++ b/shell-setup/deno.json
@@ -13,7 +13,8 @@
     "@david/which": "jsr:@david/which@^0.4.1",
     "@nathanwhit/promptly": "jsr:@nathanwhit/promptly@^0.1.2",
     "@std/cli": "jsr:@std/cli@^1.0.6",
-    "@std/path": "jsr:@std/path@^1.0.4"
+    "@std/path": "jsr:@std/path@^1.0.4",
+    "@types/node": "npm:@types/node@*"
   },
   "publish": {
     "exclude": ["./bundle.ts"]

--- a/shell-setup/deno.lock
+++ b/shell-setup/deno.lock
@@ -31,6 +31,7 @@
     "jsr:@std/path@^1.0.4": "1.0.6",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/streams@0.221": "0.221.0",
+    "npm:@types/node@*": "22.5.4",
     "npm:esbuild@*": "0.23.1"
   },
   "jsr": {
@@ -245,6 +246,12 @@
     "@esbuild/win32-x64@0.23.1": {
       "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg=="
     },
+    "@types/node@22.5.4": {
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
     "esbuild@0.23.1": {
       "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "dependencies": [
@@ -273,6 +280,9 @@
         "@esbuild/win32-ia32",
         "@esbuild/win32-x64"
       ]
+    },
+    "undici-types@6.19.8": {
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     }
   },
   "workspace": {
@@ -282,7 +292,8 @@
           "jsr:@david/which@~0.4.1",
           "jsr:@nathanwhit/promptly@~0.1.2",
           "jsr:@std/cli@^1.0.6",
-          "jsr:@std/path@^1.0.4"
+          "jsr:@std/path@^1.0.4",
+          "npm:@types/node@*"
         ]
       }
     }


### PR DESCRIPTION
There's an implicit `@types/node` dependency when publishing, since we use node builtin modules. Combined with a frozen lockfile this caused publishing to fail.

To catch this in the future, I added `deno publish --dry-run` to CI.