### PR TITLE
Display help message even when script crashes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # TODO(everyone): Keep this script simple and easily auditable.
 
 echo
-echo "End Up Stuck? Join our Discord https://discord.gg/deno"
+echo "Stuck? Join our Discord https://discord.gg/deno"
 set -e
 
 if ! command -v unzip >/dev/null && ! command -v 7z >/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 # Copyright 2019 the Deno authors. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
 
+echo
+echo "End Up Stuck? Join our Discord https://discord.gg/deno"
 set -e
 
 if ! command -v unzip >/dev/null && ! command -v 7z >/dev/null; then
@@ -112,5 +114,3 @@ if command -v deno >/dev/null; then
 else
 	echo "Run '$exe --help' to get started"
 fi
-echo
-echo "Stuck? Join our Discord https://discord.gg/deno"


### PR DESCRIPTION
Move the help message to the top. Otherwise errors will cause the message to not be shown