### PR TITLE
fix: clarify multiSelect controls in completions prompt

### DIFF
--- a/shell-setup/bundled.esm.js
+++ b/shell-setup/bundled.esm.js
@@ -1696,7 +1696,7 @@ async function setupShells(installDir, backupDir, opts) {
   }
   const shellsWithCompletion = availableShells.filter((s) => s.supportsCompletion !== false);
   const selected = skipPrompts ? [] : await multiSelect({
-    message: `Set up completions?`,
+    message: `Set up completions? (Space to toggle, Up/Down to navigate, Enter to confirm)`,
     options: shellsWithCompletion.map((s) => {
       const maybeNotes = typeof s.supportsCompletion === "string" ? ` (${s.supportsCompletion})` : "";
       return s.name + maybeNotes;

--- a/shell-setup/src/main.ts
+++ b/shell-setup/src/main.ts
@@ -204,7 +204,8 @@ async function setupShells(
   );
   const selected = skipPrompts ? [] : await multiSelect(
     {
-      message: `Set up completions?`,
+      message:
+        `Set up completions? (Space to toggle, Up/Down to navigate, Enter to confirm)`,
       options: shellsWithCompletion.map((s) => {
         const maybeNotes = typeof s.supportsCompletion === "string"
           ? ` (${s.supportsCompletion})`


### PR DESCRIPTION
## Problem

A user got stuck during `deno install` here:

```
Set up completions?
> [ ] bash
```

The `[ ]` checkbox has no visible affordance for how to interact with it — Space toggles, arrows navigate, Enter confirms.

## Fix

Cosmetic change: append `(Space to toggle, Up/Down to navigate, Enter to confirm)` to the prompt message.

`@nathanwhit/promptly`'s `MultiSelectOptions` has no `instructions` field, so the hint goes inline in `message`.

## Reporter

Originally reported in a downstream project at friday-platform/friday-studio#231.

## Notes

`shell-setup/bundled.esm.js` regenerated via `cd shell-setup && deno task bundle`.
